### PR TITLE
attempt to fix overflow in radio type controller

### DIFF
--- a/src/main/java/com/krab/lazy/nodes/AbstractNode.java
+++ b/src/main/java/com/krab/lazy/nodes/AbstractNode.java
@@ -122,19 +122,32 @@ public abstract class AbstractNode {
         fillForegroundBasedOnMouseOver(pg);
         String trimmedText = FontStore.getSubstringFromStartToFit(pg, text, size.x - FontStore.textMarginX);
         pg.textAlign(LEFT, CENTER);
-        pg.text(trimmedText, FontStore.textMarginX, LayoutStore.cell - FontStore.textMarginY);
+		//float strHeight = pg.textAscent() + pg.textDescent();
+        //using native processing function text() with defined box parameter to trim the text - alternative to author function
+		//pg.text(text, FontStore.textMarginX, LayoutStore.cell - FontStore.textMarginY, size.x - FontStore.textMarginX, strHeight );
+		pg.text(trimmedText, FontStore.textMarginX, LayoutStore.cell - FontStore.textMarginY);
     }
 
     protected void drawRightText(PGraphics pg, String text, boolean fillBackground) {
+        pg.textAlign(RIGHT, CENTER);
         if(fillBackground){
-            float w = pg.textWidth(text) + FontStore.textMarginX * 2;
+            float w = pg.textWidth(text) + FontStore.textMarginX * 2; //this needs to reflect trimmed text size
             drawRightBackdrop(pg, w);
         }
+        pg.text(text,size.x - FontStore.textMarginX,size.y - FontStore.textMarginY, );
+    }
+    
+    protected void drawRightTextWithOffset(PGraphics pg, String text, boolean fillBackground, String lefttext) {
         pg.textAlign(RIGHT, CENTER);
-        pg.text(text,
-                size.x - FontStore.textMarginX,
-                size.y - FontStore.textMarginY
-        );
+        //it should be whatever space is left from the text on the left side....
+        String trimmedTextLeft = FontStore.getSubstringFromEndToFit(pg, lefttext, size.x - FontStore.textMarginX); 
+		float leftOffset = textWidth(trimmedTextLeft)+(FontStore.textMarginX*2); //left margin + margin between the texts
+        String trimmedText = FontStore.getSubstringFromEndToFit(pg, text, size.x-leftOffset ); //fit whatever space is left
+        if(fillBackground){
+            float w = pg.textWidth(trimmedText) + FontStore.textMarginX * 2;
+            drawRightBackdrop(pg, w);
+        }
+        pg.text(trimmedText,size.x - FontStore.textMarginX,size.y - FontStore.textMarginY, );
     }
 
     protected void drawRightBackdrop(PGraphics pg, float backdropSize) {

--- a/src/main/java/com/krab/lazy/nodes/RadioFolderNode.java
+++ b/src/main/java/com/krab/lazy/nodes/RadioFolderNode.java
@@ -63,7 +63,8 @@ public class RadioFolderNode extends FolderNode {
      // don't draw folder icon - do not call super.drawNodeForeground(pg, name)
         drawLeftText(pg, name);
         drawRightBackdrop(pg, cell);
-        drawRightText(pg, valueString, true);
+        drawRightTextWithOffset(pg, valueString, true, name); //we need to calculate how much space is left for value after the name is displayed
+		//drawRightText(pg, valueString, true);
     }
 
     @Override


### PR DESCRIPTION
Issue: https://github.com/KrabCode/LazyGui/issues/264
radio control overflows

getSubstringFromStartToFit() is only used for most of the left text, title and text node content, it's not used for the right text 

I have created new function that accepts bot left and right text and thus should be able to calculate proper offsets.
![longRadio2](https://github.com/KrabCode/LazyGui/assets/50262885/a134521e-0370-42e4-96f6-d18fd083ef8d)
