### PR TITLE
Include data resources (font + shaders) in build artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,13 +21,28 @@ dependencies {
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
 }
 
+// Include the top-level `data` directory as a resources source so Gradle's processResources
+// and the resulting jars (including shadowJar) will package files like the font and shaders.
+sourceSets {
+    main {
+        resources.srcDir 'data'
+    }
+}
+
 shadowJar {
     archiveClassifier = 'with-gson'
     dependencies {
         //noinspection GroovyAssignabilityCheck
         include(dependency('com.google.code.gson:gson:2.8.9'))
     }
-    from("data")
+    // Keep including the data directory explicitly for the shadow JAR task as well.
+    from("data") {
+        // Only include the font and the checkerboard shader explicitly to ensure they're packaged.
+        include 'JetBrainsMono-Regular.ttf'
+        include 'shaders/checkerboard.glsl'
+        // Also include any additional shaders that the library expects
+        include 'shaders/**'
+    }
     from("library.properties")
     from compileJava
     from processResources


### PR DESCRIPTION
Fixes this error (using LazyGui through Jitpack)
```
The font "JetBrainsMono-Regular.ttf" is missing or inaccessible, make sure the URL is valid or that the file has been added to your sketch and is readable.
The file "shaders/checkerboard.glsl" is missing or inaccessible, make sure the URL is valid or that the file has been added to your sketch and is readable.
```